### PR TITLE
Fix mobile overflow issue with sponsorship logos

### DIFF
--- a/src/components/AboutComponent.vue
+++ b/src/components/AboutComponent.vue
@@ -51,7 +51,7 @@
       </div>
       <div class="mx-auto my-16 pb-6 pt-2">
         <p class="text-center font-display text-3xl sm:text-5xl text-white mb-8">Sponsored By</p>
-        <div class="mb-8 mx-6 flex-row text-center" style="display: flex;">
+        <div class="mb-8 mx-6 text-center" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr))">
           <img src="@/assets/teck_logo_RGB_REVERSE.png" style="max-height:200px;max-width:350px" class="mx-auto w-full"/>
           <img src="@/assets/cisco-logo3.png" style="max-height:200px; max-width:350px" class="mx-auto w-full"/>
         </div>


### PR DESCRIPTION
This is using css grids rather than tailwind's `flex-row` property.

The `grid-tempate-colums` style on line 84 ensures that the smallest
width of an image can be 250px. if there is extra space, `auto-fit` will
ensure the images take as much space as possible on the row. otherwise,
the element will overflow to a new row.

for additional info, see [this page](https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/) (or message me)